### PR TITLE
feat: main banner carousel 구현 및 Nav, ModalLayout 공통 컴포넌트 작성

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,14 @@
+{
+  "presets": [
+    [
+      "next/babel",
+      {
+        "preset-react": {
+          "runtime": "automatic",
+          "importSource": "@emotion/react"
+        }
+      }
+    ]
+  ],
+  "plugins": ["@emotion/babel-plugin"]
+}

--- a/components/login/GoogleLogin.tsx
+++ b/components/login/GoogleLogin.tsx
@@ -1,7 +1,68 @@
-import React from 'react';
+import styled from '@emotion/styled';
+import { useRef } from 'react';
 
-function GoogleLogin() {
-  return <div></div>;
+type Props = {
+  setLoginSuccess: () => void;
+  setModalOn: React.Dispatch<React.SetStateAction<boolean>>;
+  setExistingUser: () => void;
+  handleGoogleInput: () => void;
+};
+
+function GoogleLogin({ setLoginSuccess, setModalOn, setExistingUser, handleGoogleInput }: Props) {
+  const googleLoginBtn = useRef(null);
+
+  return (
+    <GoogleLoginBox id="gSignInWrapper">
+      <span className="label" />
+      <div
+        ref={googleLoginBtn}
+        id="customBtn"
+        className="customGPlusSignIn"
+        // onClick={googleLoginClickHandler}
+      >
+        <span className="icon"></span>
+        <span className="buttonText">구글로 로그인하기</span>
+      </div>
+    </GoogleLoginBox>
+  );
 }
 
 export default GoogleLogin;
+
+const GoogleLoginBox = styled.div`
+  #customBtn {
+    width: 184px;
+    height: 38px;
+    border: none;
+    margin-top: 85px;
+    margin-bottom: 3px;
+    padding-left: 4%;
+    display: flex;
+    align-items: center;
+    border-radius: 5px;
+    background-color: rgba(255, 153, 0, 0.7);
+  }
+  #customBtn:hover {
+    cursor: pointer;
+  }
+  span.label {
+    font-family: ${({ theme }) => theme.fontContent};
+    font-weight: normal;
+  }
+  span.icon {
+    background: url('/Images/google_logo.svg') no-repeat;
+    background-size: 50%;
+    background-position: center;
+    display: inline-block;
+    vertical-align: middle;
+    width: 42px;
+    height: 42px;
+  }
+  span.buttonText {
+    font-family: ${({ theme }) => theme.fontContent};
+    font-size: 14px;
+    line-height: 16px;
+    text-align: center;
+    color: ${({ theme }) => theme.white};
+  }
+`;

--- a/components/login/Login.tsx
+++ b/components/login/Login.tsx
@@ -1,7 +1,13 @@
-import React from 'react';
+import styled from '@emotion/styled';
 
-function Login() {
-  return <div></div>;
+type Props = {
+  setModalOn: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+function Login({ setModalOn }: Props) {
+  return <LoginBox></LoginBox>;
 }
 
 export default Login;
+
+const LoginBox = styled.div``;

--- a/components/login/Login.tsx
+++ b/components/login/Login.tsx
@@ -1,13 +1,63 @@
 import styled from '@emotion/styled';
+import { ModalLayout } from 'library/components/modal';
+import LogoBox from 'library/components/modal/LogoBox';
+import GoogleLogin from './GoogleLogin';
 
 type Props = {
   setModalOn: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 function Login({ setModalOn }: Props) {
-  return <LoginBox></LoginBox>;
+  return (
+    <ModalLayout width="675px" height="470px" closeModal={() => setModalOn(false)}>
+      <LoginBox>
+        <LogoBox />
+        <LoginBoxRight>
+          <Greeting>
+            <div className="greeting">환영합니다!</div>
+            <div className="type">로그인</div>
+          </Greeting>
+          <GoogleLogin
+            setLoginSuccess={() => {}}
+            setModalOn={setModalOn}
+            setExistingUser={() => {}}
+            handleGoogleInput={() => {}}
+          />
+        </LoginBoxRight>
+      </LoginBox>
+    </ModalLayout>
+  );
 }
 
 export default Login;
 
-const LoginBox = styled.div``;
+const LoginBox = styled.div`
+  display: flex;
+  width: 100%;
+  height: 100%;
+`;
+
+const LoginBoxRight = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  flex-direction: column;
+`;
+
+const Greeting = styled.div`
+  .greeting {
+    font-weight: bold;
+    font-size: 18px;
+    line-height: 26px;
+    color: #525151;
+  }
+
+  .type {
+    margin-top: 12px;
+    font-style: normal;
+    font-weight: bold;
+    font-size: 26px;
+    line-height: 30px;
+    color: #000000;
+  }
+`;

--- a/components/mainBanner/BannerContents.ts
+++ b/components/mainBanner/BannerContents.ts
@@ -1,16 +1,15 @@
 export const bannerContents = [
   {
     id: 'siteIn',
-    img: '/Images/main_banner1.png',
+    img: '/images/main_banner1.png',
     title: 'WOW!',
     subtitle: 'Well done!',
     content: '혹쉬...이번달 명예의 전당에 혹시 내 이름이!?지금 당장 확인하러 가보자!',
     link: '/MyGroup',
   },
-
   {
     id: 'siteOut',
-    img: '/Images/main_banner2.png',
+    img: '/images/main_banner2.png',
     title: 'Hi',
     subtitle: 'wechicken OPEN!',
     content:
@@ -19,7 +18,7 @@ export const bannerContents = [
   },
   {
     id: 'siteOut',
-    img: '/Images/main_banner3.png',
+    img: '/images/main_banner3.png',
     title: 'Hi',
     subtitle: 'Made by JWT',
     content: 'wechicken 솔직히 너무 멋지다... 누가 만들었냐구요? 바로바로~ JWT(현쥐,쥰,요쥬,토큰)',
@@ -27,10 +26,18 @@ export const bannerContents = [
   },
   {
     id: 'siteOut',
-    img: '/Images/main_banner4.png',
+    img: '/images/main_banner4.png',
     title: 'HOT!',
     subtitle: "I can't wait!",
     content: '이달의 HOT 블로그는 뭘까요? 핫하다 핫해! 지금 바로 공부하러 가보자! ',
     link: '',
+  },
+  {
+    id: 'siteIn',
+    img: '/images/main_banner1.png',
+    title: 'WOW!',
+    subtitle: 'Well done!',
+    content: '혹쉬...이번달 명예의 전당에 혹시 내 이름이!?지금 당장 확인하러 가보자!',
+    link: '/MyGroup',
   },
 ];

--- a/components/mainBanner/MainBanner.tsx
+++ b/components/mainBanner/MainBanner.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import styled from '@emotion/styled';
-import { bannerContents } from './BannerContents';
 import { useRouter } from 'next/dist/client/router';
+import styled from '@emotion/styled';
+import { bannerContents } from 'components/mainBanner/BannerContents';
 
 type Props = {
   setActiveAlert: React.Dispatch<React.SetStateAction<boolean>>;
@@ -48,15 +48,12 @@ const MainBanner = ({ setActiveAlert }: Props) => {
               <TitleText>{content.subtitle}</TitleText>
               <Detail>{content.content}</Detail>
               <MoreBtn
-                onClick={
-                  () =>
-                    content.id !== 'siteIn' // ? router.push(`${content.link}`)
-                      ? console.log(content.link)
-                      : console.log('yes')
-                  //   : JSON.parse(sessionStorage.getItem('USER') ?? '') !== ''
-                  //   ? // ? router.push(`${content.link}`)
-                  //     console.log(JSON.parse(sessionStorage.getItem('USER') ?? ''))
-                  //   : setActiveAlert(true)
+                onClick={() =>
+                  content.id !== 'siteIn'
+                    ? router.push(`${content.link}`)
+                    : JSON.parse(sessionStorage.getItem('USER') ?? '')
+                    ? router.push(`${content.link}`)
+                    : setActiveAlert(true)
                 }
               >
                 더보기 ▸

--- a/components/mainBanner/MainBanner.tsx
+++ b/components/mainBanner/MainBanner.tsx
@@ -48,12 +48,15 @@ const MainBanner = ({ setActiveAlert }: Props) => {
               <TitleText>{content.subtitle}</TitleText>
               <Detail>{content.content}</Detail>
               <MoreBtn
-                onClick={() =>
-                  content.id !== 'siteIn'
-                    ? window.location.assign(`${content.link}`)
-                    : JSON.parse(sessionStorage.getItem('USER') ?? '') !== ''
-                    ? router.push(`${content.link}`)
-                    : setActiveAlert(true)
+                onClick={
+                  () =>
+                    content.id !== 'siteIn' // ? router.push(`${content.link}`)
+                      ? console.log(content.link)
+                      : console.log('yes')
+                  //   : JSON.parse(sessionStorage.getItem('USER') ?? '') !== ''
+                  //   ? // ? router.push(`${content.link}`)
+                  //     console.log(JSON.parse(sessionStorage.getItem('USER') ?? ''))
+                  //   : setActiveAlert(true)
                 }
               >
                 더보기 ▸

--- a/components/mainBanner/MainBanner.tsx
+++ b/components/mainBanner/MainBanner.tsx
@@ -12,7 +12,7 @@ const MainBanner = ({ setActiveAlert }: Props) => {
   const [count, setCount] = useState(0);
   const intervalRef = useRef<null | ReturnType<typeof setTimeout>>(null);
   const isFirstRender = useRef(true);
-  let intervalTime = !isFirstRender.current && count === 0 ? 1 : 2000;
+  let intervalTime = !isFirstRender.current && count === 0 ? 1 : 4000;
 
   const start = useCallback(() => {
     if (intervalRef.current !== null) {
@@ -20,7 +20,7 @@ const MainBanner = ({ setActiveAlert }: Props) => {
     }
 
     if (isFirstRender.current) {
-      intervalTime = 2000;
+      intervalTime = 4000;
     }
 
     intervalRef.current = setInterval(() => {

--- a/components/mainBanner/MainBanner.tsx
+++ b/components/mainBanner/MainBanner.tsx
@@ -1,40 +1,67 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
 import styled from '@emotion/styled';
 import { bannerContents } from './BannerContents';
+import { useRouter } from 'next/dist/client/router';
 
 type Props = {
   setActiveAlert: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 const MainBanner = ({ setActiveAlert }: Props) => {
+  const [count, setCount] = useState(0);
+  const intervalRef = useRef<null | ReturnType<typeof setTimeout>>(null);
+  const delayTime = 4000;
+  const router = useRouter();
+
+  const start = useCallback(() => {
+    if (intervalRef.current !== null) {
+      return;
+    }
+    intervalRef.current = setInterval(() => {
+      setCount(prev => (prev === bannerContents.length - 1 ? 0 : prev + 1));
+    }, delayTime);
+  }, []);
+
+  const stop = useCallback(() => {
+    if (intervalRef.current === null) {
+      return;
+    }
+    clearInterval(intervalRef.current);
+    intervalRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    start();
+    return () => {
+      stop();
+    };
+  }, []);
+
   return (
     <MainBannerContainer>
-      {bannerContents.map((content, i) => {
-        return (
-          <div className="bannerWrap" key={i}>
-            <img className="bannerImg" alt="bannerImg" src={content.img} />
+      <CarouselWrapper count={count} onMouseEnter={stop} onMouseLeave={start}>
+        {bannerContents.map((content, idx) => (
+          <BannerWrap key={idx}>
+            <img alt={`banner${idx}`} src={content.img} />
             <BannerContent>
-              <h1 className="greeting">{content.title}</h1>
-              <h2 className="title">{content.subtitle}</h2>
-              <div className="text">
-                <p>{content.content}</p>
-              </div>
-              <button
+              <GreetingText>{content.title}</GreetingText>
+              <TitleText>{content.subtitle}</TitleText>
+              <Detail>{content.content}</Detail>
+              <MoreBtn
                 onClick={() =>
-                  // content.id !== 'siteIn'
-                  //   ? window.location.assign(`${content.link}`)
-                  //   : JSON.parse(sessionStorage.getItem('USER'))
-                  //   ? history.push(`${content.link}`)
-                  // :
-                  setActiveAlert(true)
+                  content.id !== 'siteIn'
+                    ? window.location.assign(`${content.link}`)
+                    : JSON.parse(sessionStorage.getItem('USER') ?? '') !== ''
+                    ? router.push(`${content.link}`)
+                    : setActiveAlert(true)
                 }
-                className="moreBtn"
               >
                 더보기 ▸
-              </button>
+              </MoreBtn>
             </BannerContent>
-          </div>
-        );
-      })}
+          </BannerWrap>
+        ))}
+      </CarouselWrapper>
     </MainBannerContainer>
   );
 };
@@ -42,19 +69,23 @@ const MainBanner = ({ setActiveAlert }: Props) => {
 export default MainBanner;
 
 const MainBannerContainer = styled.div`
+  width: 100%;
+  max-width: 1600px;
+  overflow-x: hidden;
+`;
+
+const CarouselWrapper = styled.div<{ count: number }>`
+  display: inline flex;
+  width: 100vw;
+  margin: 0 auto;
+  transition: 900ms;
+  transform: ${({ count }) => `translate3d(${-count * 100}%, 0, 0)`};
+`;
+
+const BannerWrap = styled.div`
   display: flex;
-  width: 1000px;
-  margin: 0 10px;
-  overflow-x: scroll;
-
-  @media (max-width: 800px) {
-    display: none;
-  }
-
-  .bannerWrap {
-    display: flex;
-    min-width: 1000px;
-  }
+  height: 100%;
+  padding: 0 10vw;
 
   img {
     width: 50%;
@@ -62,39 +93,39 @@ const MainBannerContainer = styled.div`
 `;
 
 const BannerContent = styled.div`
-  width: 35%;
-  padding: 10px 0 0 75px;
   display: flex;
   flex-direction: column;
+  padding: 10px 0 0 75px;
   font-family: ${({ theme }) => theme.fontContent};
   font-weight: 600;
+  word-break: keep-all;
+`;
 
-  .greeting {
-    font-size: 39px;
-    color: ${({ theme }) => theme.orange};
-  }
+const GreetingText = styled.h1`
+  font-size: 39px;
+  color: ${({ theme }) => theme.orange};
+`;
 
-  .title {
-    font-size: 35px;
-  }
+const TitleText = styled.h2`
+  font-size: 35px;
+`;
 
-  p {
-    margin-top: 140px;
-    line-height: 30px;
-    font-size: 20px;
-    font-weight: 300;
-    font-family: ${({ theme }) => theme.fontContent};
-  }
+const Detail = styled.p`
+  margin-top: 140px;
+  line-height: 30px;
+  font-size: 20px;
+  font-weight: 300;
+  font-family: ${({ theme }) => theme.fontContent};
+`;
 
-  .moreBtn {
-    margin-top: 20px;
-    display: flex;
-    justify-content: flex-end;
-    border: none;
-    outline: none;
-    font-size: 17px;
-    background-color: transparent;
-    color: ${({ theme }) => theme.orange};
-    cursor: pointer;
-  }
+const MoreBtn = styled.button`
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 20px;
+  border: none;
+  outline: none;
+  font-size: 17px;
+  background-color: transparent;
+  color: ${({ theme }) => theme.orange};
+  cursor: pointer;
 `;

--- a/components/nav/Nav.tsx
+++ b/components/nav/Nav.tsx
@@ -1,7 +1,144 @@
-import React from 'react';
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/dist/client/router';
+import Link from 'next/link';
+import styled from '@emotion/styled';
+import Alert from 'library/components/alert/Alert';
+import Login from 'components/login/Login';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCog } from '@fortawesome/free-solid-svg-icons';
 
 function Nav() {
-  return <div></div>;
+  const router = useRouter();
+  const [isdropDownOpen, setDropDownOpen] = useState(false);
+  const [selectedMenu, setSelectedMenu] = useState('');
+  const [isModalOn, setModalOn] = useState(false);
+  const [isCreateMyGroupModalOn, setCreateMyGroupModalOn] = useState(false);
+  const [isModifyMyGroup, setModifyMyGroup] = useState(false);
+  const [isActiveAlert, setActiveAlert] = useState(false);
+
+  const handleSelectedFunctions = (selected: string) => {
+    setDropDownOpen(false);
+    if (selected === '로그아웃') {
+      setActiveAlert(true);
+    }
+  };
+
+  useEffect(() => {
+    handleSelectedFunctions(selectedMenu);
+  }, [selectedMenu]);
+
+  return (
+    <>
+      {isActiveAlert && (
+        <Alert
+          setActiveAlert={setActiveAlert}
+          setSelectedMenu={setSelectedMenu}
+          selectedMenu={selectedMenu}
+          alertMessage={'로그아웃 하시겠습니까?'}
+          excuteFunction={() => {
+            sessionStorage.removeItem('USER');
+            router.push('/');
+            window.location.reload();
+          }}
+          submitBtn={'확인'}
+          closeBtn={'취소'}
+        />
+      )}
+      <NavBox onMouseLeave={() => setDropDownOpen(false)}>
+        {isModalOn && <Login setModalOn={setModalOn} />}
+
+        <LogoWrap>
+          <Link href="/">
+            <Logo onClick={() => setSelectedMenu('')}>
+              <img className="logoImage" alt="logo" src="/Images/logo.png" />
+              <div className="logoText">&gt;wechicken</div>
+            </Logo>
+          </Link>
+        </LogoWrap>
+        <UserWrap></UserWrap>
+      </NavBox>
+    </>
+  );
 }
 
 export default Nav;
+
+const NavBox = styled.div`
+  position: fixed;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  height: 111px;
+  padding: 0 8vw;
+  background-color: ${({ theme }) => theme.white};
+  z-index: 9;
+
+  a {
+    text-decoration: none;
+    color: inherit;
+  }
+`;
+
+const LogoWrap = styled.div`
+  width: 422px;
+  height: 52px;
+  display: flex;
+  align-items: center;
+
+  .settingMyGroup {
+    margin-left: 15px;
+    color: ${({ theme }) => theme.deepGrey};
+    cursor: pointer;
+    opacity: 0.7;
+  }
+  .settingMyGroup:hover {
+    opacity: 1;
+  }
+`;
+
+const Logo = styled.a`
+  display: flex;
+  align-items: center;
+  width: 190px;
+
+  .logoImage {
+    width: 51px;
+    height: 52px;
+    margin-right: 10px;
+    border-radius: 50px;
+  }
+
+  .logoText {
+    width: 130px;
+    font-family: ${({ theme }) => theme.fontTitle};
+    font-weight: 500;
+    font-size: 20px;
+    line-height: 27px;
+    color: #2d2b2b;
+  }
+`;
+
+const NthTitle = styled.div`
+  font-family: ${({ theme }) => theme.fontTitle};
+  font-style: normal;
+  font-weight: bold;
+  font-size: 18px;
+  line-height: 21px;
+  color: ${({ theme }) => theme.orange};
+`;
+
+const UserWrap = styled.div`
+  display: flex;
+  justify-content: center;
+  height: 47px;
+  position: relative;
+
+  .masterCrown {
+    width: 25px;
+    height: 25px;
+    position: absolute;
+    top: -20px;
+    right: 12px;
+  }
+`;

--- a/components/nav/Nav.tsx
+++ b/components/nav/Nav.tsx
@@ -9,6 +9,7 @@ import Button from 'library/components/button/Button';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCog } from '@fortawesome/free-solid-svg-icons';
 
+// TODO 작성 중
 function Nav() {
   const router = useRouter();
   const [isdropDownOpen, setDropDownOpen] = useState(false);
@@ -39,14 +40,14 @@ function Nav() {
           setActiveAlert={setActiveAlert}
           setSelectedMenu={setSelectedMenu}
           selectedMenu={selectedMenu}
-          alertMessage={'로그아웃 하시겠습니까?'}
+          alertMessage="로그아웃 하시겠습니까?"
           excuteFunction={() => {
             sessionStorage.removeItem('USER');
             router.push('/');
             window.location.reload();
           }}
-          submitBtn={'확인'}
-          closeBtn={'취소'}
+          submitBtn="확인"
+          closeBtn="취소"
         />
       )}
       <NavBox onMouseLeave={() => setDropDownOpen(false)}>

--- a/components/nav/Nav.tsx
+++ b/components/nav/Nav.tsx
@@ -2,8 +2,10 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/dist/client/router';
 import Link from 'next/link';
 import styled from '@emotion/styled';
-import Alert from 'library/components/alert/Alert';
 import Login from 'components/login/Login';
+import Alert from 'library/components/alert/Alert';
+import ProfileIcon from 'library/components/profileIcon/ProfileIcon';
+import Button from 'library/components/button/Button';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCog } from '@fortawesome/free-solid-svg-icons';
 
@@ -22,6 +24,9 @@ function Nav() {
       setActiveAlert(true);
     }
   };
+
+  let loginStatus = false;
+  let userProfileImg = '';
 
   useEffect(() => {
     handleSelectedFunctions(selectedMenu);
@@ -46,16 +51,28 @@ function Nav() {
       )}
       <NavBox onMouseLeave={() => setDropDownOpen(false)}>
         {isModalOn && <Login setModalOn={setModalOn} />}
-
         <LogoWrap>
-          <Link href="/">
+          <Link href="/" passHref>
             <Logo onClick={() => setSelectedMenu('')}>
               <img className="logoImage" alt="logo" src="/Images/logo.png" />
               <div className="logoText">&gt;wechicken</div>
             </Logo>
           </Link>
         </LogoWrap>
-        <UserWrap></UserWrap>
+        <UserWrap>
+          {loginStatus ? (
+            <>
+              {JSON.parse(sessionStorage.getItem('USER') ?? '')?.master && (
+                <img className="masterCrown" alt="master" src="/Images/crown.png" />
+              )}
+              <div onMouseOver={() => setDropDownOpen(true)}>
+                <ProfileIcon size={50} img={userProfileImg} />
+              </div>
+            </>
+          ) : (
+            <Button value="로그인" handleFunction={() => setModalOn(true)} />
+          )}
+        </UserWrap>
       </NavBox>
     </>
   );
@@ -69,15 +86,10 @@ const NavBox = styled.div`
   align-items: center;
   justify-content: space-between;
   width: 100%;
+  padding: 0 10px;
   height: 111px;
-  padding: 0 8vw;
   background-color: ${({ theme }) => theme.white};
   z-index: 9;
-
-  a {
-    text-decoration: none;
-    color: inherit;
-  }
 `;
 
 const LogoWrap = styled.div`
@@ -101,6 +113,8 @@ const Logo = styled.a`
   display: flex;
   align-items: center;
   width: 190px;
+  text-decoration: none;
+  color: ${({ theme }) => theme.fontColor};
 
   .logoImage {
     width: 51px;
@@ -115,7 +129,6 @@ const Logo = styled.a`
     font-weight: 500;
     font-size: 20px;
     line-height: 27px;
-    color: #2d2b2b;
   }
 `;
 

--- a/library/components/alert/Alert.tsx
+++ b/library/components/alert/Alert.tsx
@@ -1,7 +1,31 @@
-import React from 'react';
+import styled from '@emotion/styled';
+import { useEffect } from 'react';
 
-function Alert() {
-  return <div></div>;
+type Props = {
+  setActiveAlert: React.Dispatch<React.SetStateAction<boolean>>;
+  alertMessage: string;
+  submitBtn: string;
+  closeBtn: string;
+  excuteFunction: () => void;
+  type?: string;
+};
+
+function Alert({ setActiveAlert, alertMessage, submitBtn, closeBtn, excuteFunction, type }: Props) {
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, []);
+
+  const handleExecuteFunction = () => {
+    excuteFunction();
+    type !== 'notice' && setActiveAlert(false);
+  };
+
+  return <AlertBox></AlertBox>;
 }
 
 export default Alert;
+
+const AlertBox = styled.div``;

--- a/library/components/alert/Alert.tsx
+++ b/library/components/alert/Alert.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { useEffect } from 'react';
+import { SetStateAction, useEffect } from 'react';
 
 type Props = {
   setActiveAlert: React.Dispatch<React.SetStateAction<boolean>>;
@@ -8,6 +8,8 @@ type Props = {
   closeBtn: string;
   excuteFunction: () => void;
   type?: string;
+  setSelectedMenu?: React.Dispatch<SetStateAction<string>>;
+  selectedMenu?: string;
 };
 
 function Alert({ setActiveAlert, alertMessage, submitBtn, closeBtn, excuteFunction, type }: Props) {

--- a/library/components/alert/Alert.tsx
+++ b/library/components/alert/Alert.tsx
@@ -12,6 +12,7 @@ type Props = {
   selectedMenu?: string;
 };
 
+// TODO 작성 중
 function Alert({ setActiveAlert, alertMessage, submitBtn, closeBtn, excuteFunction, type }: Props) {
   useEffect(() => {
     document.body.style.overflow = 'hidden';

--- a/library/components/button/BtnEditOrDelete.tsx
+++ b/library/components/button/BtnEditOrDelete.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import styled from '@emotion/styled';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faEllipsisH } from '@fortawesome/free-solid-svg-icons';
+
+type Props = {
+  postId: number;
+  handlePostId: (id: number) => void;
+  getDeleteMyPostId: (id: number) => void;
+};
+
+function BtnEditOrDelete({ postId, handlePostId, getDeleteMyPostId }: Props) {
+  const [isBtnClicked, setBtnClicked] = useState(false);
+
+  const handleBtnClicked = () => {
+    setBtnClicked(true);
+  };
+
+  return (
+    <>
+      {isBtnClicked && (
+        <DropDown onMouseLeave={() => setBtnClicked(false)}>
+          <p onClick={() => handlePostId(postId)}>수정</p>
+          <p onClick={() => getDeleteMyPostId(postId)}>삭제</p>
+        </DropDown>
+      )}
+      <Container>
+        <FontAwesomeIcon
+          onMouseOver={handleBtnClicked}
+          className="editOrDeleteBtn"
+          icon={faEllipsisH}
+        />
+      </Container>
+    </>
+  );
+}
+
+export default BtnEditOrDelete;
+
+const Container = styled.div`
+  position: absolute;
+  right: 3px;
+  color: ${({ theme }) => theme.fontColor};
+`;
+
+const DropDown = styled.div`
+  position: absolute;
+  right: -10px;
+  top: -10px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 150px;
+  padding: 3px 10px;
+  border-radius: 8px;
+  background-color: white;
+  box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.06), 0px 8px 16px rgba(0, 0, 0, 0.1);
+  z-index: 3;
+
+  p {
+    margin: 10px 5px;
+    font-size: 14px;
+    color: ${({ theme }) => theme.fontColor};
+    cursor: pointer;
+  }
+
+  p:last-child {
+    color: ${({ theme }) => theme.vermilion};
+  }
+`;

--- a/library/components/button/BtnLike.tsx
+++ b/library/components/button/BtnLike.tsx
@@ -1,0 +1,78 @@
+import styled from '@emotion/styled';
+import React, { useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faHeart as blankHeart } from '@fortawesome/free-regular-svg-icons';
+import { faHeart as filledHeart } from '@fortawesome/free-solid-svg-icons';
+import { faBookmark as blankBookmarks } from '@fortawesome/free-regular-svg-icons';
+import { faBookmark as filledBookmarks } from '@fortawesome/free-solid-svg-icons';
+
+type Props = {
+  id: number;
+  status: boolean;
+  type: string;
+  setActiveAlert: React.Dispatch<React.SetStateAction<boolean>>;
+  handleRemoveCard?: (() => void) | undefined;
+};
+
+function BtnLike({ id, status, handleRemoveCard, type, setActiveAlert }: Props) {
+  const [isLiked, setLiked] = useState(status ?? false);
+
+  const fetchLikeStatus = () => {
+    // TODO like api call 코드 추가
+  };
+
+  const handleLikeStatus = () => {
+    setLiked(!isLiked);
+    // TODO 작성 필요
+    // if (handleRemoveCard) setTimeout(() => handleRemoveCard(id, type), 500);
+    fetchLikeStatus();
+  };
+
+  const checkLoginStatus = () => {
+    if (JSON.parse(sessionStorage.getItem('USER') ?? '')) {
+      return handleLikeStatus();
+    }
+    return setActiveAlert(true);
+  };
+
+  return (
+    <BtnLikeBox type={type} onClick={checkLoginStatus}>
+      <BlankIcon isLiked={isLiked}>
+        <FontAwesomeIcon className="blank" icon={type === 'likes' ? blankHeart : blankBookmarks} />
+      </BlankIcon>
+      <FilledIcon isLiked={isLiked} type={type}>
+        <FontAwesomeIcon
+          className="filled"
+          icon={type === 'likes' ? filledHeart : filledBookmarks}
+        />
+      </FilledIcon>
+    </BtnLikeBox>
+  );
+}
+
+export default BtnLike;
+
+const BtnLikeBox = styled.div<{ type: string }>`
+  position: absolute;
+  right: ${({ type }) => (type === 'likes' ? '29' : '2')}px;
+`;
+
+const BlankIcon = styled.div<{ isLiked: boolean }>`
+  display: ${({ isLiked }) => (isLiked ? 'none' : 'block')};
+
+  .blank {
+    width: 20px;
+    height: 20px;
+    color: ${({ theme }) => theme.deepGrey};
+  }
+`;
+
+const FilledIcon = styled.div<{ isLiked: boolean; type: string }>`
+  display: ${({ isLiked }) => (isLiked ? 'block' : 'none')};
+
+  .filled {
+    width: 20px;
+    height: 20px;
+    color: ${({ type, theme }) => (type === 'likes' ? theme.vermilion : theme.middleGrey)};
+  }
+`;

--- a/library/components/button/Button.tsx
+++ b/library/components/button/Button.tsx
@@ -1,7 +1,26 @@
+import styled from '@emotion/styled';
 import React from 'react';
 
-function Button() {
-  return <div></div>;
+type Props = {
+  value: string;
+  handleFunction: () => void;
+};
+
+function Button({ value, handleFunction }: Props) {
+  return <Container onClick={handleFunction}>{value}</Container>;
 }
 
 export default Button;
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 82px;
+  height: 32px;
+  color: ${({ theme }) => theme.white};
+  background-color: ${({ theme }) => theme.orange};
+  border-radius: 1rem;
+  cursor: pointer;
+  font-family: ${({ theme }) => theme.fontContent};
+`;

--- a/library/components/card/Card.tsx
+++ b/library/components/card/Card.tsx
@@ -1,4 +1,7 @@
 import styled from '@emotion/styled';
+import ProfileIcon from 'library/components/profileIcon/ProfileIcon';
+import BtnLike from 'library/components/button/BtnLike';
+import BtnEditOrDelete from 'library/components/button/BtnEditOrDelete';
 import { Post } from 'library/models/main';
 
 type Props = {
@@ -7,10 +10,9 @@ type Props = {
   space: number;
   setActiveAlert: React.Dispatch<React.SetStateAction<boolean>>;
   handleRemoveCard?: () => void;
-  handleModifyModal?: () => void;
   search?: boolean;
-  handlePostId?: number;
-  getDeleteMyPostId?: number;
+  handlePostId?: (id: number) => void;
+  getDeleteMyPostId?: (id: number) => void;
 };
 
 function Card({
@@ -19,7 +21,6 @@ function Card({
   space,
   handleRemoveCard,
   setActiveAlert,
-  handleModifyModal,
   search,
   handlePostId,
   getDeleteMyPostId,
@@ -33,7 +34,7 @@ function Card({
         <img className="blogLogo" alt="blog_logo" src={`/Images/${post.type}.png`} />
         <ContentsBox>
           <Profile>
-            {/* <ProfileIcon size={40} img={post.user_profile} /> */}
+            <ProfileIcon size={40} img={post.user_profile} />
             <div className="ProfileText">
               <div className="nth">{post.nth}기</div>
               <div className="name">{post.user_name}</div>
@@ -51,31 +52,33 @@ function Card({
       </CardWrap>
       <Tags>{post.date}</Tags>
       <ButtonWrap>
-        {/* {typeof post.like === 'boolean' ? (
+        {typeof post.like === 'boolean' ? (
           <>
             <BtnLike
               id={post.id}
               status={post.like}
               handleRemoveCard={handleRemoveCard}
-              type={'likes'}
+              type="likes"
               setActiveAlert={setActiveAlert}
             />
             <BtnLike
               id={post.id}
               status={post.bookmark}
               handleRemoveCard={handleRemoveCard}
-              type={'bookmarks'}
+              type="bookmarks"
               setActiveAlert={setActiveAlert}
             />
           </>
         ) : (
-          <BtnEditOrDelete
-            postId={post.id}
-            handlePostId={handlePostId}
-            getDeleteMyPostId={getDeleteMyPostId}
-            handleModifyModal={handleModifyModal}
-          />
-        )} */}
+          handlePostId &&
+          getDeleteMyPostId && (
+            <BtnEditOrDelete
+              postId={post.id}
+              handlePostId={handlePostId}
+              getDeleteMyPostId={getDeleteMyPostId}
+            />
+          )
+        )}
       </ButtonWrap>
     </CardContainer>
   );

--- a/library/components/loading/Loading.tsx
+++ b/library/components/loading/Loading.tsx
@@ -4,8 +4,8 @@ import { flexCenter } from 'styles/theme';
 function Loading() {
   return (
     <LoadingContainer>
-      <div className="loadingText"></div>
-      <div className="loadingImg"></div>
+      <LoadingText/>
+      <LoadingImg/>
     </LoadingContainer>
   );
 }
@@ -17,28 +17,28 @@ const LoadingContainer = styled.div`
   height: 100vh;
   ${flexCenter};
 
-  .loadingText {
-    width: 320px;
-    height: 320px;
-    background: url('/images/loading.png');
-    background-size: contain;
-    animation: rotate_image 7s linear infinite;
-    transform-origin: 50% 50%;
-  }
-
   @keyframes rotate_image {
     100% {
       transform: rotate(360deg);
     }
   }
+`;
 
-  .loadingImg {
-    width: 200px;
-    height: 200px;
-    border-radius: 50%;
-    position: absolute;
-    background: url('/images/doghair.jpg');
-    background-position: center;
-    background-repeat: no-repeat;
-  }
+const LoadingText = styled.div`
+  width: 320px;
+  height: 320px;
+  background: url('/images/loading.png');
+  background-size: contain;
+  animation: rotate_image 7s linear infinite;
+  transform-origin: 50% 50%;
+`;
+
+const LoadingImg = styled.div`
+  width: 200px;
+  height: 200px;
+  border-radius: 50%;
+  position: absolute;
+  background: url('/images/doghair.jpg');
+  background-position: center;
+  background-repeat: no-repeat;
 `;

--- a/library/components/modal/LogoBox.tsx
+++ b/library/components/modal/LogoBox.tsx
@@ -1,7 +1,34 @@
-import React from 'react';
+import styled from '@emotion/styled';
 
 function LogoBox() {
-  return <div></div>;
+  return (
+    <Container>
+      <img className="logoImage" alt="logo" src="/images/logo.png" />
+      <span>{`>wechicken`}</span>
+    </Container>
+  );
 }
 
 export default LogoBox;
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  width: 50%;
+
+  .logoImage {
+    width: 157px;
+    height: 157px;
+  }
+
+  span {
+    margin-top: 10px;
+    font-family: ${({ theme }) => theme.fontTitle};
+    font-weight: bold;
+    font-size: 18px;
+    line-height: 24px;
+    color: ${({ theme }) => theme.fontColor};
+  }
+`;

--- a/library/components/modal/ModalLayout.tsx
+++ b/library/components/modal/ModalLayout.tsx
@@ -1,7 +1,61 @@
-import React from 'react';
+import styled from '@emotion/styled';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
 
-function ModalLayout() {
-  return <div></div>;
+type Props = {
+  children: React.ReactNode;
+  width: string;
+  height: string;
+  padding?: string;
+  closeModal?: () => void;
+  style?: object;
+};
+
+function ModalLayout({ children, closeModal, style, width, height, padding }: Props) {
+  return (
+    <Dimmer>
+      <ModalBox width={width} height={height} padding={padding} style={style}>
+        {closeModal && <FontAwesomeIcon onClick={closeModal} className="BtnClose" icon={faTimes} />}
+        {children}
+      </ModalBox>
+    </Dimmer>
+  );
 }
 
 export default ModalLayout;
+
+const Dimmer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  width: 100vw;
+  height: 100vh;
+  z-index: 10;
+  background-color: rgba(0, 0, 0, 0.3);
+`;
+
+const ModalBox = styled.div<{ width: string; height: string; padding: string | undefined }>`
+  position: relative;
+  width: ${({ width }) => width};
+  height: ${({ height }) => height};
+  padding: ${({ padding }) => (padding ? padding : '10px')};
+  border-radius: 3px;
+  background-color: ${({ theme }) => theme.white};
+  box-shadow: -14px -14px 20px rgba(0, 0, 0, 0.02), 14px 14px 20px rgba(0, 0, 0, 0.05);
+  z-index: 11;
+
+  .BtnClose {
+    position: absolute;
+    right: 0;
+    width: 21px;
+    height: 21px;
+    margin: 15px;
+    color: ${({ theme }) => theme.deepGrey};
+    cursor: pointer;
+  }
+`;

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-query": "^3.19.0"
   },
   "devDependencies": {
+    "@emotion/babel-plugin": "^11.3.0",
     "@types/lodash-es": "^4.17.4",
     "@types/react": "17.0.14",
     "@types/react-calendar": "^3.4.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,11 @@
   "dependencies": {
     "@emotion/react": "^11.4.0",
     "@emotion/styled": "^11.3.0",
+    "@fortawesome/fontawesome": "^1.1.8",
+    "@fortawesome/fontawesome-svg-core": "^1.2.30",
+    "@fortawesome/free-regular-svg-icons": "^5.14.0",
+    "@fortawesome/free-solid-svg-icons": "^5.14.0",
+    "@fortawesome/react-fontawesome": "^0.1.11",
     "@reduxjs/toolkit": "^1.6.0",
     "axios": "^0.21.1",
     "dayjs": "^1.10.6",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,11 +21,11 @@ export default function Home() {
   const { data, fetchNextPage, hasNextPage } = useInfiniteQuery(
     'getMainPage',
     async ({ pageParam = 0 }) => {
-      const { status, data } = await getMainPage(pageParam as number);
+      const { status, data } = await getMainPage(pageParam);
       return status === 200 && data;
     },
     {
-      getPreviousPageParam: firstPage => (firstPage as any)?.previousId ?? false,
+      getPreviousPageParam: firstPage => firstPage?.previousId ?? false,
       getNextPageParam: lastPage => {
         if (isNil(lastPage)) {
           return undefined;
@@ -76,7 +76,7 @@ export default function Home() {
           </MainContentTitle>
           <MainContentCards>
             {data?.pages.map(page =>
-              (page as any)?.posts.map((post: Post) => (
+              page?.posts.map((post: Post) => (
                 <Card
                   key={post.id}
                   post={post}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,28 +1,23 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { useInfiniteQuery, useQuery } from 'react-query';
-import { isNil } from 'lodash-es';
 import styled from '@emotion/styled';
+import { useInfiniteQuery } from 'react-query';
+import { isNil } from 'lodash-es';
 import MainBanner from 'components/mainBanner/MainBanner';
-import { useIntersectionObserver } from 'library/hooks/useIntersectionObserver';
+import Login from 'components/login/Login';
 import Card from 'library/components/card/Card';
-import Loading from 'library/components/loading/Loading';
+import Alert from 'library/components/alert/Alert';
 import { Post } from 'library/models/main';
 import { getMainPage } from 'library/api';
+import { useIntersectionObserver } from 'library/hooks/useIntersectionObserver';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCheck } from '@fortawesome/free-solid-svg-icons';
 
 export default function Home() {
   const [isActiveAlert, setActiveAlert] = useState(false);
   const [isLoginActive, setLoginActive] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const pageRef = useRef(0);
-  const {
-    data,
-    error,
-    isFetching,
-    isFetchingNextPage,
-    fetchNextPage,
-    fetchPreviousPage,
-    hasNextPage,
-  } = useInfiniteQuery(
+  const { data, fetchNextPage, hasNextPage } = useInfiniteQuery(
     'getMainPage',
     async ({ pageParam = 0 }) => {
       const { status, data } = await getMainPage(pageParam as number);
@@ -30,7 +25,7 @@ export default function Home() {
     },
     {
       getPreviousPageParam: firstPage => (firstPage as any)?.previousId ?? false,
-      getNextPageParam: (lastPage, allPages) => {
+      getNextPageParam: lastPage => {
         if (isNil(lastPage)) {
           return undefined;
         }
@@ -56,30 +51,24 @@ export default function Home() {
     enabled: hasNextPage,
   });
 
-  // TODO Loading 컴포넌트 연결 필요
-  // if (isFetching) return <Loading />;
-
-  // TODO Login 및 Alert 컴포넌트 작성 필요
   return (
     <>
-      {/* {isLoginActive && <Login setModalOn={setLoginActive} />} */}
-      {/* {isActiveAlert && (
+      {isLoginActive && <Login setModalOn={setLoginActive} />}
+      {isActiveAlert && (
         <Alert
           setActiveAlert={setActiveAlert}
-          alertMessage={'로그인이 필요한 서비스입니다.'}
-          submitBtn={'로그인'}
-          closeBtn={'취소'}
+          alertMessage="로그인이 필요한 서비스입니다."
+          submitBtn="로그인"
+          closeBtn="취소"
           excuteFunction={handleSetLoginActive}
         />
-      )} */}
+      )}
       <HomeContainer>
         <MainBanner setActiveAlert={setActiveAlert} />
         <MainContents>
           <MainContentTitle>
             <div className="titleContainer">
-              {/* 
-              TODO 교체 필요
-              <FontAwesomeIcon className='check' icon={faCheck} /> */}
+              <FontAwesomeIcon className="check" icon={faCheck} />
               <h1 className="contentTitle">트렌딩 포스트</h1>
             </div>
           </MainContentTitle>
@@ -104,29 +93,31 @@ export default function Home() {
 }
 
 const HomeContainer = styled.div`
-  padding-top: 150px;
   display: flex;
   flex-direction: column;
   align-items: center;
+  padding-top: 150px;
   color: ${({ theme }) => theme.deepGrey};
   background-color: ${({ theme }) => theme.background};
 `;
 
 const MainContentCards = styled.div`
-  margin-top: 40px;
-  padding: 0px !important;
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
+  margin-top: 40px;
+  padding: 0px !important;
 `;
 
 const MainContents = styled.div`
+  position: relative;
   width: 90%;
   max-width: 1450px;
   padding: 50px 0;
   margin-top: 55px;
-  position: relative;
   border-radius: 50px;
+  background-color: ${({ theme }) => theme.white};
+  box-shadow: 7px 7px 30px rgba(0, 0, 0, 0.05);
 
   @media (max-width: 800px) {
     margin-top: 0px;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import styled from '@emotion/styled';
 import { useInfiniteQuery } from 'react-query';
 import { isNil } from 'lodash-es';
+import Nav from 'components/nav/Nav';
 import MainBanner from 'components/mainBanner/MainBanner';
 import Login from 'components/login/Login';
 import Card from 'library/components/card/Card';
@@ -53,6 +54,7 @@ export default function Home() {
 
   return (
     <>
+      <Nav />
       {isLoginActive && <Login setModalOn={setLoginActive} />}
       {isActiveAlert && (
         <Alert

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,6 +239,51 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fortawesome/fontawesome-common-types@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.1.7.tgz#4336c4b06d0b5608ff1215464b66fcf9f4795284"
+  integrity sha512-ego8jRVSHfq/iq4KRZJKQeUAdi3ZjGNrqw4oPN3fNdvTBnLCSntwVCnc37bsAJP9UB8MhrTfPnZYxkv2vpS4pg==
+
+"@fortawesome/fontawesome-common-types@^0.2.36":
+  version "0.2.36"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz#b44e52db3b6b20523e0c57ef8c42d315532cb903"
+  integrity sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==
+
+"@fortawesome/fontawesome-svg-core@^1.2.30":
+  version "1.2.36"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz#4f2ea6f778298e0c47c6524ce2e7fd58eb6930e3"
+  integrity sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.36"
+
+"@fortawesome/fontawesome@^1.1.8":
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome/-/fontawesome-1.1.8.tgz#75fe66a60f95508160bb16bd781ad7d89b280f5b"
+  integrity sha512-c0/MtkPVT0fmiFcCyYoPjkG9PkMOvfrZw2+0BaJ+Rh6UEcK1AR/LaRgrHHjUkbAbs9LXxQJhFS8CJ4uSnK2+JA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.1.7"
+
+"@fortawesome/free-regular-svg-icons@^5.14.0":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.15.4.tgz#b97edab436954333bbeac09cfc40c6a951081a02"
+  integrity sha512-9VNNnU3CXHy9XednJ3wzQp6SwNwT3XaM26oS4Rp391GsxVYA+0oDR2J194YCIWf7jNRCYKjUCOduxdceLrx+xw==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.36"
+
+"@fortawesome/free-solid-svg-icons@^5.14.0":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz#2a68f3fc3ddda12e52645654142b9e4e8fbb6cc5"
+  integrity sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.36"
+
+"@fortawesome/react-fontawesome@^0.1.11":
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.15.tgz#1450b838f905981d721bf07e14e3b52c0e9a91ed"
+  integrity sha512-/HFHdcoLESxxMkqZAcZ6RXDJ69pVApwdwRos/B2kiMWxDSAX2dFK8Er2/+rG+RsrzWB/dsAyjefLmemgmfE18g==
+  dependencies:
+    prop-types "^15.7.2"
+
 "@hapi/accept@5.0.2":
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@hapi/accept/-/accept-5.0.2.tgz#ab7043b037e68b722f93f376afb05e85c0699523"


### PR DESCRIPTION
# ✍🏼 작업 내용
## 메인 배너 캐러셀 추가
- 기존 사이트와 동일한 UI 설정
- 마우스를 올릴 경우 stop. 
- 추후 user auth 세팅 되면 session.storage 부분 수정 필요

## Navbar 및 Login Modal UI 작성
- google login 코드 작성 필요

## 공통 컴포넌트 작성
- Modal Layout 공통 컴포넌트 작성 (Alert.tsx 수정 예정)
- Button 작성 완료

## emotion/babel-plugin 추가 및 babelrc 작성
- emotion className autoLabel을 위해 플러그인 추가 
![image](https://user-images.githubusercontent.com/69200669/129456083-dbff76a8-cef1-4be5-91b2-11b0d64dcdbf.png)

# 🌆 스크린샷
![image](https://user-images.githubusercontent.com/69200669/129455960-a5e4cdeb-4fb5-4426-a48b-2f921bdee5b6.png)

![Kapture 2021-08-14 at 22 35 40](https://user-images.githubusercontent.com/69200669/129447998-62b766d7-b2cd-41b0-a053-b8b8c5dd0c4e.gif)