### PR TITLE
refactor: profileIcon next/image 변경

### DIFF
--- a/library/components/profileIcon/ProfileIcon.tsx
+++ b/library/components/profileIcon/ProfileIcon.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import Image from 'next/image';
 
 export type ProfileIconProps = {
   size: number;
@@ -6,15 +7,23 @@ export type ProfileIconProps = {
 };
 
 export default function ProfileIcon({ size, img }: ProfileIconProps): JSX.Element {
-  return <ProfileIconBox size={size} img={img}></ProfileIconBox>;
+  return (
+    <ProfileIconBox size={size} img={img}>
+      <Image
+        src={img || '/images/default.png'}
+        alt="profile"
+        width={`${size}px`}
+        height={`${size}px`}
+      />
+    </ProfileIconBox>
+  );
 }
 
 const ProfileIconBox = styled.div<ProfileIconProps>`
   width: ${({ size }) => size}px;
   height: ${({ size }) => size}px;
-  background: url(${({ img }) => img || '/images/default.png'});
-  background-size: cover;
   border-radius: 50%;
-  cursor: pointer;
   border: 1px solid ${({ theme }) => theme.superLightGrey};
+  cursor: pointer;
+  overflow: hidden;
 `;

--- a/next.config.js
+++ b/next.config.js
@@ -7,4 +7,7 @@ module.exports = withTM({
     STAGE: process.env.STAGE,
     GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
   },
+  images: {
+    domains: ['lh3.googleusercontent.com', 'jwtbucket.s3.ap-northeast-2.amazonaws.com'],
+  },
 });


### PR DESCRIPTION
# ✍🏼 작업 내용
- profile icon 이미 최적화 위해 next/image로 변경
```javascript
export default function ProfileIcon({ size, img }: ProfileIconProps): JSX.Element {
  return (
    <ProfileIconBox size={size} img={img}>
      <Image
        src={img || '/images/default.png'}
        alt="profile"
        width={`${size}px`}
        height={`${size}px`}
      />
    </ProfileIconBox>
  );
}
```
