### PR TITLE
feat: toast 컴포넌트 추가

### DIFF
--- a/components/myGroup/contributors/contributor.tsx
+++ b/components/myGroup/contributors/contributor.tsx
@@ -68,7 +68,7 @@ const UserInfo = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  width: 60px;
+  width: 90px;
   margin-left: 5px;
 
   .name {

--- a/components/myGroup/contributors/contributors.tsx
+++ b/components/myGroup/contributors/contributors.tsx
@@ -111,7 +111,6 @@ const InfoContainer = styled.div`
 const UserInfo = styled.div`
   display: flex;
   align-items: center;
-  width: 90px;
   margin-left: 5px;
 
   .user-container {

--- a/components/myProfile/ProfileColumn.tsx
+++ b/components/myProfile/ProfileColumn.tsx
@@ -11,6 +11,7 @@ import { faEdit } from '@fortawesome/free-solid-svg-icons';
 import { deleteProfileImage, getMyProfile, modifyBlogUrl, modifyProfileImage } from 'library/api';
 import ProfileIcon from 'library/components/profileIcon/ProfileIcon';
 import Loading from 'library/components/loading/Loading';
+import { useToast } from 'library/hooks';
 
 function ProfileColumn(): JSX.Element {
   const dispatch = useDispatch();
@@ -18,6 +19,7 @@ function ProfileColumn(): JSX.Element {
 
   const [isEdit, setisEdit] = useState<boolean>(false);
   const [contentValue, setContentValue] = useState<string>('');
+  const { showToast } = useToast();
   const { data, refetch } = useQuery(
     'getMyProfile',
     async () => {
@@ -53,7 +55,16 @@ function ProfileColumn(): JSX.Element {
 
   const { mutate: mutateBlogUrl } = useMutation(
     (blogAddress: string) => modifyBlogUrl(blogAddress),
-    { onSuccess: () => refetch() },
+    {
+      onSuccess: () => refetch(),
+      onError: () => {
+        setContentValue(data?.blog_address ?? '');
+        showToast({
+          message:
+            '블로그 주소를 변경하는 데 실패했습니다.<br />블로그 url의 형식이 올바른지 다시 한 번 확인해 주세요.',
+        });
+      },
+    },
   );
 
   // 수정 아이콘

--- a/components/toast/Toast.tsx
+++ b/components/toast/Toast.tsx
@@ -1,0 +1,92 @@
+import styled from '@emotion/styled';
+import { useEffect, useState } from 'react';
+import { toastSelector } from 'library/store/toast';
+import { useSelector } from 'react-redux';
+
+function Toast(): JSX.Element | null {
+  const [isToastOpen, setIsToastOpen] = useState<boolean>(false);
+  const [isFirstRender, setIsFirstRender] = useState<boolean>(true);
+
+  const toastConfig = useSelector(toastSelector);
+
+  const showToast = (duration: number): void => {
+    if (isFirstRender || duration === 0) {
+      return;
+    }
+
+    setIsToastOpen(true);
+
+    setTimeout(() => {
+      setIsToastOpen(false);
+    }, duration);
+  };
+
+  useEffect(() => {
+    setIsFirstRender(false);
+  }, []);
+
+  useEffect(() => {
+    showToast(toastConfig.duration ?? 3000);
+  }, [toastConfig]);
+
+  if (!isToastOpen) {
+    return null;
+  }
+
+  return (
+    <ToastWrapper>
+      <ToastBox
+        duration={toastConfig.duration ?? 3000}
+        dangerouslySetInnerHTML={{ __html: toastConfig.message }}
+      ></ToastBox>
+    </ToastWrapper>
+  );
+}
+
+export default Toast;
+
+const ToastWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  position: fixed;
+  inset: 0;
+`;
+
+const ToastBox = styled.div<{ duration: number }>`
+  position: fixed;
+  bottom: 50px;
+  max-width: 50rem;
+  text-align: center;
+  padding: 0.8rem 2.3rem;
+  background-color: white;
+  color: ${({ theme }) => theme.darkGrey};
+  border-radius: 8px;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
+  z-index: 1000000;
+
+  ${({ theme }) => theme.sm`
+    max-width: 80%;
+  `}
+
+  @keyframes fadeIn {
+    0% {
+      opacity: 0;
+    }
+
+    100% {
+      opacity: 1;
+    }
+  }
+
+  @keyframes fadeOut {
+    0% {
+      opacity: 1;
+    }
+
+    100% {
+      opacity: 0;
+    }
+  }
+
+  animation: fadeIn 0.3s ease-in, fadeOut 0.3s ${({ duration }) => duration / 1000 - 0.3}s ease-in;
+`;

--- a/library/components/Layout/Layout.tsx
+++ b/library/components/Layout/Layout.tsx
@@ -7,6 +7,7 @@ import { useIntersectionObserver } from 'library/hooks';
 import { useSelector } from 'react-redux';
 import { alertForm } from 'library/store/setAlert';
 import { loginModal } from 'library/store/setLoginModal';
+import Toast from 'components/toast/Toast';
 
 type Props = {
   children: React.ReactNode;
@@ -47,6 +48,7 @@ export default function Layout({ children }: Props): JSX.Element {
       <Nav isBlurred={isBlurred} setBlurred={setBlurred} />
       <main>{children}</main>
       <Observer ref={ref} />
+      <Toast />
     </LayoutBox>
   );
 }

--- a/library/components/button/BtnLike.tsx
+++ b/library/components/button/BtnLike.tsx
@@ -9,6 +9,7 @@ import { faHeart as blankHeart } from '@fortawesome/free-regular-svg-icons';
 import { faHeart as filledHeart } from '@fortawesome/free-solid-svg-icons';
 import { faBookmark as blankBookmarks } from '@fortawesome/free-regular-svg-icons';
 import { faBookmark as filledBookmarks } from '@fortawesome/free-solid-svg-icons';
+import { useToast } from 'library/hooks';
 
 type Props = {
   id: number;
@@ -22,6 +23,7 @@ function BtnLike({ id, status, type, setActiveAlert, handleRemoveCard }: Props):
   const user = useSelector(currentUser);
   const [isLiked, setLiked] = useState(status ?? false);
   const likeStatus = useMutation(([type, id]: [string, number]) => postLikeStatus(type, id));
+  const { showToast } = useToast();
 
   const fetchLikeStatus = async (): Promise<void> => {
     const { data, status } = await likeStatus.mutateAsync([type, id]);
@@ -30,8 +32,7 @@ function BtnLike({ id, status, type, setActiveAlert, handleRemoveCard }: Props):
       const type = data.message === 'LIKED' ? '좋아요' : '북마크';
       const action = isLiked === true ? '에서 삭제' : '에 추가';
 
-      // TODO 토스트 알람 있으면 좋을 것 같아요
-      console.log(`${type} 목록${action}되었습니다.`);
+      showToast({ message: `${type} 목록${action}되었습니다.` });
     }
   };
 

--- a/library/hooks/index.ts
+++ b/library/hooks/index.ts
@@ -1,2 +1,3 @@
-export * from 'library/hooks/useIntersectionObserver';
-export * from 'library/hooks/useUpload';
+export * from './useIntersectionObserver';
+export * from './useUpload';
+export * from './useToast';

--- a/library/hooks/useToast.ts
+++ b/library/hooks/useToast.ts
@@ -1,0 +1,32 @@
+import { ToastConfig } from 'library/models';
+import { setToastConfig } from 'library/store/toast';
+import { useDispatch } from 'react-redux';
+
+type UseToast = {
+  showToast: (config: ToastConfig) => void;
+};
+
+/**
+ * toast를 띄우고 싶은 컴포넌트에서 사용하는 hook.
+ * 리턴되는 `showToast` 함수를 사용하여 토스트를 띄울 수 있다.
+ * @returns showToast
+ * @example
+ * const {showToast} = useToast();
+ *
+ * const onClick = () => {
+ *   showToast({message: 'hello world!'});
+ * }
+ */
+export const useToast = (): UseToast => {
+  const dispatch = useDispatch();
+
+  /**
+   * 토스트를 띄우는 `action`을 `dispatch`하는 함수.
+   * @param config duration의 단위는 ms, 기본값 `3000` message는 innerHTML로 집어넣어서 `hello<br />world!` 가능쓰
+   */
+  const showToast = (config: ToastConfig): void => {
+    dispatch(setToastConfig(config));
+  };
+
+  return { showToast };
+};

--- a/library/models/index.ts
+++ b/library/models/index.ts
@@ -1,2 +1,3 @@
-export * from 'library/models/main';
-export * from 'library/models/myprofile';
+export * from './main';
+export * from './myprofile';
+export * from './toast';

--- a/library/models/toast.ts
+++ b/library/models/toast.ts
@@ -1,0 +1,4 @@
+export type ToastConfig = {
+  message: string;
+  duration?: number;
+};

--- a/library/store/index.ts
+++ b/library/store/index.ts
@@ -2,12 +2,14 @@ import { configureStore, getDefaultMiddleware } from '@reduxjs/toolkit';
 import user from 'library/store/saveUser';
 import isLoginModalOn from 'library/store/setLoginModal';
 import alert from 'library/store/setAlert';
+import toast from './toast';
 
 export const store = configureStore({
   reducer: {
     user,
     isLoginModalOn,
     alert,
+    toast,
   },
   middleware: [
     ...getDefaultMiddleware({

--- a/library/store/toast.ts
+++ b/library/store/toast.ts
@@ -1,0 +1,25 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { ToastConfig } from 'library/models';
+import { AppState } from '.';
+
+const INITIAL_STATE: ToastConfig = {
+  message: '',
+  duration: 3000,
+};
+
+export const toastSlice = createSlice({
+  name: 'toast',
+  initialState: INITIAL_STATE,
+  reducers: {
+    setToastConfig: (_, action: PayloadAction<ToastConfig>) => {
+      const { message, duration } = action.payload;
+
+      return { message, duration: duration ?? 3000 };
+    },
+  },
+});
+
+export const { setToastConfig } = toastSlice.actions;
+export const toastSelector = (state: AppState): ToastConfig => state.toast;
+
+export default toastSlice.reducer;


### PR DESCRIPTION
# ✍🏼 작업 내용

 - toast 컴포넌트, 그에 필요한 redux state, custom hook을 작성했습니다
 - toast 관련 TODO 제거

# 🌆 스크린샷


![toast](https://user-images.githubusercontent.com/26221261/134801349-02c3317e-0ae6-4932-a035-7a7f44239241.gif)

# ❓ 사용 방법

<img width="766" alt="스크린샷 2021-09-26 오후 6 10 28" src="https://user-images.githubusercontent.com/26221261/134801375-42ea43d4-0a5b-47a0-898e-f1f7c8987231.png">
짤곧내...

Toast를 띄우고싶은 컴포넌트에서 `useToast` 훅을 사용하고, `useToast` 훅에서 리턴되는 `showToast` 함수를 호출하면 토스트가 뿅하고 나타납니다

jsdoc 작성해두었기 떄무네 훅이나 함수에 마우스 올려보시면 사용법 알수있워요~~

